### PR TITLE
Update ha_monitor.yaml

### DIFF
--- a/packages/ha-core/areas/cabinet/devices/home_assistant/ha_monitor.yaml
+++ b/packages/ha-core/areas/cabinet/devices/home_assistant/ha_monitor.yaml
@@ -108,7 +108,7 @@ alert:
     state: 'on'
     can_acknowledge: false
     repeat: 360
-    title: "Updates available in {{ states('sensor.hacs') }} HACS repo{% if states('sensor.hacs') | int > 1 %}s{% endif %}"
+    title: "Updates available in {{ states('sensor.hacs') }} HACS repo{% if states('sensor.hacs') | int >= 1 %}s{% endif %}"
     message: ""
     notifiers:
       - firebase_home_assistant
@@ -125,7 +125,7 @@ alert:
     state: 'on'
     can_acknowledge: false
     repeat: 360
-    title: "Updates available for {{ states('sensor.supervisor_updates') }} HA addon{% if states('sensor.supervisor_updates') | int > 1 %}s{% endif %}"
+    title: "Updates available for {{ states('sensor.supervisor_updates') }} HA addon{% if states('sensor.supervisor_updates') | int >= 1 %}s{% endif %}"
     message: ""
     notifiers:
     - firebase_home_assistant
@@ -147,7 +147,7 @@ binary_sensor:
         entity_id:
         - sensor.supervisor_updates
         value_template: "{{ state_attr('sensor.supervisor_updates', 'current_version') != state_attr('sensor.supervisor_updates', 'newest_version') }}"
-        availability_template: "{{ (states('sensor.supervisor_updates') | int(-1)) > -1 }}"
+        availability_template: "{{ (states('sensor.supervisor_updates') | int(-1)) >= -1 }}"
 
       # True if there's updates available for any HACS components
       updater_hacs:
@@ -242,7 +242,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # VSCode Addon
   - platform: rest
@@ -256,7 +256,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # ESPHome Addon
   - platform: rest
@@ -270,7 +270,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # PHPMyAdmin Addon
   - platform: rest
@@ -284,7 +284,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # ADB Addon
   - platform: rest
@@ -298,12 +298,12 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
-# AdGaurd Addon
+# AdGuard Addon
   - platform: rest
     resource: !secret adgaurd_rest_url
-    name: AdGaurd Addon
+    name: AdGuard Addon
     value_template: '{{ value_json.data.state }}'
     scan_interval: 60
     headers:
@@ -312,7 +312,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # Deconz Addon
   - platform: rest
@@ -326,7 +326,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # Mosquitto Addon
   - platform: rest
@@ -340,7 +340,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # SSH & Terminal Addon
   - platform: rest
@@ -354,7 +354,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # MariaDB Addon
   - platform: rest
@@ -368,7 +368,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 # Node-Red Addon
   - platform: rest
@@ -382,7 +382,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
   - platform: rest
     resource: !secret vscode_rest_url
@@ -395,7 +395,7 @@ sensor:
     json_attributes_path: "$.data"
     json_attributes:
       - version
-      - last_version
+      - version_latest
 
 
 switch:

--- a/packages/ha-core/areas/cabinet/devices/home_assistant/ha_monitor.yaml
+++ b/packages/ha-core/areas/cabinet/devices/home_assistant/ha_monitor.yaml
@@ -108,7 +108,7 @@ alert:
     state: 'on'
     can_acknowledge: false
     repeat: 360
-    title: "Updates available in {{ states('sensor.hacs') }} HACS repo{% if states('sensor.hacs') | int >= 1 %}s{% endif %}"
+    title: "Updates available in {{ states('sensor.hacs') }} HACS repo{% if states('sensor.hacs') | int > 1 %}s{% endif %}"
     message: ""
     notifiers:
       - firebase_home_assistant
@@ -125,7 +125,7 @@ alert:
     state: 'on'
     can_acknowledge: false
     repeat: 360
-    title: "Updates available for {{ states('sensor.supervisor_updates') }} HA addon{% if states('sensor.supervisor_updates') | int >= 1 %}s{% endif %}"
+    title: "Updates available for {{ states('sensor.supervisor_updates') }} HA addon{% if states('sensor.supervisor_updates') | int > 1 %}s{% endif %}"
     message: ""
     notifiers:
     - firebase_home_assistant
@@ -147,7 +147,7 @@ binary_sensor:
         entity_id:
         - sensor.supervisor_updates
         value_template: "{{ state_attr('sensor.supervisor_updates', 'current_version') != state_attr('sensor.supervisor_updates', 'newest_version') }}"
-        availability_template: "{{ (states('sensor.supervisor_updates') | int(-1)) >= -1 }}"
+        availability_template: "{{ (states('sensor.supervisor_updates') | int(-1)) > -1 }}"
 
       # True if there's updates available for any HACS components
       updater_hacs:
@@ -300,20 +300,6 @@ sensor:
       - version
       - version_latest
 
-# AdGuard Addon
-  - platform: rest
-    resource: !secret adgaurd_rest_url
-    name: AdGuard Addon
-    value_template: '{{ value_json.data.state }}'
-    scan_interval: 60
-    headers:
-      Authorization: !secret access_token
-      Content-Type: application/json
-    json_attributes_path: "$.data"
-    json_attributes:
-      - version
-      - version_latest
-
 # Deconz Addon
   - platform: rest
     resource: !secret deconz_rest_url
@@ -374,19 +360,6 @@ sensor:
   - platform: rest
     resource: !secret node_red_rest_url
     name: Node-Red Addon
-    value_template: '{{ value_json.data.state }}'
-    scan_interval: 60
-    headers:
-      Authorization: !secret access_token
-      Content-Type: application/json
-    json_attributes_path: "$.data"
-    json_attributes:
-      - version
-      - version_latest
-
-  - platform: rest
-    resource: !secret vscode_rest_url
-    name: VSCode Addon
     value_template: '{{ value_json.data.state }}'
     scan_interval: 60
     headers:
@@ -462,18 +435,6 @@ switch:
           service: hassio.addon_stop
           data:
             addon: a0d7b954_adb
-
-# Adgaurd Switch Template
-      adguard_addon:
-        value_template: "{{ is_state('sensor.adguard_addon', 'started') }}"
-        turn_on:
-          service: hassio.addon_start
-          data:
-            addon: a0d7b954_adguard
-        turn_off:
-          service: hassio.addon_stop
-          data:
-            addon: a0d7b954_adguard
 
 # Deconz Switch Template
       deconz_addon:


### PR DESCRIPTION
hacs values > 1 results in no update available when theres only 1 update for hacs. making it >= results in a better feedback.
also, API has changed, it's no longer last_version, but version_latest

also some typo's in AdGuard where you had AdGaurd (you might want to change your !secret name too.